### PR TITLE
Handle empty metadata on source PDF

### DIFF
--- a/src/action.py
+++ b/src/action.py
@@ -111,7 +111,7 @@ class PDFCoverAction(InterfaceAction):
                 new_pdf.add_page(cover_pdf_page)
 
                 # Check for watermark
-                if self.watermark in book.metadata:
+                if book.metadata is not None and self.watermark in book.metadata:
                     # Add all but first page to new PDF
                     new_pdf.append(book, None, PageRange("1:"))
                 else:
@@ -119,11 +119,12 @@ class PDFCoverAction(InterfaceAction):
                     new_pdf.append(book)
 
                 # Update watermark
+                metadata = {} if book.metadata is None else book.metadata
                 new_pdf.add_metadata(
-                        {
-                            **book.metadata,
-                            self.watermark : "true"
-                        }
+                    {
+                        **metadata,
+                        self.watermark: "true"
+                    }
                 )
 
                 # Write new pdf


### PR DESCRIPTION
I ran into an exception on a PDF that had no metadata, resulting in this stacktrace:
```
Traceback (most recent call last):
  File "calibre_plugins.pdf_cover.action", line 65, in insert_covers
    self.prepend_cover(book, cover)
  File "calibre_plugins.pdf_cover.action", line 116, in prepend_cover
    if self.watermark in book.metadata:
       ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
TypeError: argument of type 'NoneType' is not iterable
```

This PR addresses that by checking if `books.metadata` is empty and handling that case appropriately.